### PR TITLE
Fix typo: "reminder" → "remainder" in code

### DIFF
--- a/recurrent/generation_manager.py
+++ b/recurrent/generation_manager.py
@@ -87,8 +87,8 @@ class LLMGenerationManager:
         bsz = input_ids.shape[0]
 
         group_nums = self.world_size
-        reminder = bsz % group_nums
-        if reminder:
+        remainder = bsz % group_nums
+        if remainder:
             # Example pattern for bsz=7, group_nums=3:
             # no_padding_mask: [1, 1, 1, 0, 1, 1, 0, 1, 1]
             # padding_index:   [0, 1, 2, -1, 3, 4, -1, 5, 6]
@@ -112,7 +112,7 @@ class LLMGenerationManager:
             'attention_mask': attention_masks
         }, meta_info=meta_info)
         output_batch = self.actor_rollout_wg.generate_sequences(batch)
-        if reminder:
+        if remainder:
             # 4. remove padding
             output_batch = indexing_proto(output_batch, no_padding_mask)
         return output_batch

--- a/recurrent/utils.py
+++ b/recurrent/utils.py
@@ -145,13 +145,13 @@ def graceful_padding(bsz: int, group_nums: int) -> tuple[torch.Tensor, torch.Ten
         A tensor containing the index mapping with padding elements marked as -1
     """
     group_size = bsz // group_nums + 1
-    reminder = bsz % group_nums
-    if not reminder:
+    remainder = bsz % group_nums
+    if not remainder:
         return torch.arange(bsz), torch.ones(bsz, dtype=torch.bool)
     
     # Create mask where 1 = no padding, 0 = padding
     no_padding_mask = torch.tensor(
-        [1 if i // group_size < reminder or i % group_size else 0 
+        [1 if i // group_size < remainder or i % group_size else 0 
          for i in range(group_nums * group_size)],
         dtype=torch.int
     )


### PR DESCRIPTION
This PR fixes a minor typo in the code where "reminder" was used instead of the correct term "remainder." The correction improves code clarity and aligns with standard terminology. No functional changes were made.