### PR TITLE
fix: close file handles in evaluation scripts to prevent resource leak

### DIFF
--- a/taskutils/memory_eval/ruler_general.py
+++ b/taskutils/memory_eval/ruler_general.py
@@ -120,6 +120,7 @@ def get_pred(data, args, out_file):
             print("-"*80)
             print(item['judge_sub_em'])
             print("="*40 + "New Item End" + "="*40)
+    fout.close()
     print(f"ruler_general [{args.length}]")
     for k, v in scores.items():
         print(f"{k}: {round(sum(v) * 100 /len(v), 2)}")

--- a/taskutils/memory_eval/ruler_hqa.py
+++ b/taskutils/memory_eval/ruler_hqa.py
@@ -97,6 +97,7 @@ def get_pred(data, args, out_file):
             print("-"*80)
             print(item['judge_sub_em'])
             print("="*40 + "New Item End" + "="*40)
+    fout.close()
     print(f"ruler_hqa [{args.length}]")
     for k, v in scores.items():
         print(f"{k}: {round(sum(v) * 100 /len(v), 2)}")

--- a/taskutils/memory_eval/ruler_hqa_over1m.py
+++ b/taskutils/memory_eval/ruler_hqa_over1m.py
@@ -98,6 +98,7 @@ def get_pred(data, args, out_file):
             print("-"*80)
             print(item['judge_sub_em'])
             print("="*40 + "New Item End" + "="*40)
+    fout.close()
     print(f"ruler_hqa [{args.length}]")
     for k, v in scores.items():
         print(f"{k}: {round(sum(v) * 100 /len(v), 2)}")


### PR DESCRIPTION
## Problem

Three evaluation scripts open output files with `open()` but never close them:
- `taskutils/memory_eval/ruler_general.py` (line 89)
- `taskutils/memory_eval/ruler_hqa.py` (line 74)
- `taskutils/memory_eval/ruler_hqa_over1m.py` (line 75)

This leaks file descriptors and risks data loss — buffered writes may not be flushed if the process exits abnormally (e.g., OOM kill, exception).

## Fix

Add `fout.close()` after each evaluation loop completes, ensuring all buffered data is flushed and the file descriptor is released.

## Files Changed

| File | Change |
|------|--------|
| `ruler_general.py` | Added `fout.close()` after evaluation loop |
| `ruler_hqa.py` | Added `fout.close()` after evaluation loop |
| `ruler_hqa_over1m.py` | Added `fout.close()` after evaluation loop |