### PR TITLE
fix: catch KeyboardInterrupt instead of bare except in serve script

### DIFF
--- a/serve/llm070.py
+++ b/serve/llm070.py
@@ -222,7 +222,6 @@ if __name__ == "__main__":
     p = subprocess.Popen(cmd, shell=True)
     try:
         p.wait()
-    except:
+    except KeyboardInterrupt:
         p.terminate()
         print("interrupted")
-        pass


### PR DESCRIPTION
The bare `except:` in `serve/llm070.py` is intended to handle Ctrl+C for graceful process termination. Replace with `except KeyboardInterrupt:` which is the actual intended signal, avoiding accidental catch of `SystemExit`.